### PR TITLE
Add support for multiple mime types

### DIFF
--- a/server/src/config.php.example
+++ b/server/src/config.php.example
@@ -3,6 +3,6 @@
 return [
     'secretBcrypt' => '',
     'saveDirName' => '/data/',
-    'maxScreenshotSize' => 128 * 1048576,
+    'maxScreenshotSize' => 2 * 1048576,
     'screenshotMimeTypes' => [ 'image/png', 'image/jpeg' ]
 ];

--- a/server/src/config.php.example
+++ b/server/src/config.php.example
@@ -3,6 +3,6 @@
 return [
     'secretBcrypt' => '',
     'saveDirName' => '/data/',
-    'maxScreenshotSize' => 2 * 1048576,
-    'screenshotMimeType' => 'image/png'
+    'maxScreenshotSize' => 128 * 1048576,
+    'screenshotMimeTypes' => [ 'image/png', 'image/jpeg' ]
 ];

--- a/server/src/upload.php
+++ b/server/src/upload.php
@@ -5,8 +5,8 @@ $config = array_replace_recursive(
     [
         'secretBcrypt' => '',
         'saveDirName' => '/data/',
-        'maxScreenshotSize' => 2 * 1048576,
-        'screenshotMimeType' => 'image/png'
+        'maxScreenshotSize' => 128 * 1048576,
+        'screenshotMimeTypes' => [ 'image/png', 'image/jpeg' ]
     ],
     file_exists('./config.php') ? include_once('./config.php') : []
 );
@@ -20,6 +20,7 @@ if (!password_verify($_POST['secret'], $config['secretBcrypt'])) {
     exit();
 }
 
+$mimetype = isset($screenshot['tmp_name']) ? mime_content_type($screenshot['tmp_name']) : "error";
 if (
     // Make sure it is a successful single file upload
     !isset($screenshot['error']) ||
@@ -27,14 +28,14 @@ if (
     $screenshot['error'] !== UPLOAD_ERR_OK ||
     // Verify size and mime type
     $screenshot['size'] > $config['maxScreenshotSize'] ||
-    mime_content_type($screenshot['tmp_name']) !== $config['screenshotMimeType']
+    !in_array( $mimetype, $config['screenshotMimeTypes']
 ) {
     http_response_code(422);
     exit();
 }
 
 // Generate screenshot path
-do {} while (file_exists($filename = bin2hex(random_bytes(12)) . '.png'));
+do {} while (file_exists($filename = bin2hex(random_bytes(12)) . '.' . ($mimetype == "image/png" ? "png" : "jpg" )));
 
 // Create save directory and move screenshot to it
 if (

--- a/server/src/upload.php
+++ b/server/src/upload.php
@@ -28,7 +28,7 @@ if (
     $screenshot['error'] !== UPLOAD_ERR_OK ||
     // Verify size and mime type
     $screenshot['size'] > $config['maxScreenshotSize'] ||
-    !in_array( $mimetype, $config['screenshotMimeTypes']
+    !in_array( $mimetype, $config['screenshotMimeTypes'], true)
 ) {
     http_response_code(422);
     exit();

--- a/server/src/upload.php
+++ b/server/src/upload.php
@@ -5,7 +5,7 @@ $config = array_replace_recursive(
     [
         'secretBcrypt' => '',
         'saveDirName' => '/data/',
-        'maxScreenshotSize' => 128 * 1048576,
+        'maxScreenshotSize' => 2 * 1048576,
         'screenshotMimeTypes' => [ 'image/png', 'image/jpeg' ]
     ],
     file_exists('./config.php') ? include_once('./config.php') : []


### PR DESCRIPTION
Apps like ShareX can send either JPG or PNG depending on file size, so I made the following adjustments to allow more than one mime type to be uploaded.

By default it is PNG and JPG.